### PR TITLE
don't check macros in check-model hooks

### DIFF
--- a/pre_commit_dbt/check_model_columns_have_desc.py
+++ b/pre_commit_dbt/check_model_columns_have_desc.py
@@ -12,6 +12,7 @@ from pre_commit_dbt.utils import add_manifest_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_model_schemas
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 from pre_commit_dbt.utils import Model
@@ -22,8 +23,8 @@ def check_column_desc(
     paths: Sequence[str], manifest: Dict[str, Any]
 ) -> Tuple[int, Dict[str, Any]]:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
     ymls = get_filenames(paths, [".yml", ".yaml"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_has_all_columns.py
+++ b/pre_commit_dbt/check_model_has_all_columns.py
@@ -9,8 +9,8 @@ from typing import Tuple
 from pre_commit_dbt.utils import add_catalog_args
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 
@@ -29,7 +29,7 @@ def check_model_columns(
     paths: Sequence[str], manifest: Dict[str, Any], catalog: Dict[str, Any]
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_has_description.py
+++ b/pre_commit_dbt/check_model_has_description.py
@@ -9,18 +9,16 @@ from pre_commit_dbt.utils import add_manifest_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_model_schemas
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 
 
 def has_description(paths: Sequence[str], manifest: Dict[str, Any]) -> int:
     status_code = 0
-    macro_paths = [m["path"] for m in manifest.get("macros", {}).values()]
-    macro_sqls = get_filenames(macro_paths, extensions=[".sql"])
-    sqls = get_filenames(paths, [".sql"])
     ymls = get_filenames(paths, [".yml", ".yaml"])
-    macro_filenames = set(macro_sqls.keys())
-    filenames = set(sqls.keys()).difference(macro_filenames)
+    sqls = get_model_sqls(paths, manifest)
+    filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed
     models = get_models(manifest, filenames)

--- a/pre_commit_dbt/check_model_has_meta_keys.py
+++ b/pre_commit_dbt/check_model_has_meta_keys.py
@@ -9,6 +9,7 @@ from pre_commit_dbt.utils import add_manifest_args
 from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
 from pre_commit_dbt.utils import get_model_schemas
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 
@@ -17,8 +18,8 @@ def has_meta_key(
     paths: Sequence[str], manifest: Dict[str, Any], meta_keys: Sequence[str]
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
     ymls = get_filenames(paths, [".yml", ".yaml"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
     # get manifest nodes that pre-commit found as changed
     models = get_models(manifest, filenames)

--- a/pre_commit_dbt/check_model_has_properties_file.py
+++ b/pre_commit_dbt/check_model_has_properties_file.py
@@ -8,8 +8,8 @@ from typing import Tuple
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 
@@ -18,7 +18,7 @@ def has_properties_file(
     paths: Sequence[str], manifest: Dict[str, Any]
 ) -> Tuple[int, Set[str]]:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_has_tests.py
+++ b/pre_commit_dbt/check_model_has_tests.py
@@ -6,8 +6,8 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import JsonOpenError
@@ -18,7 +18,7 @@ def check_test_cnt(
     paths: Sequence[str], manifest: Dict[str, Any], test_cnt: int
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_has_tests_by_group.py
+++ b/pre_commit_dbt/check_model_has_tests_by_group.py
@@ -7,8 +7,8 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import JsonOpenError
@@ -22,7 +22,7 @@ def check_test_cnt(
     test_cnt: int,
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_has_tests_by_name.py
+++ b/pre_commit_dbt/check_model_has_tests_by_name.py
@@ -7,8 +7,8 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import JsonOpenError
@@ -20,7 +20,7 @@ def check_test_cnt(
     paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int]
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_has_tests_by_type.py
+++ b/pre_commit_dbt/check_model_has_tests_by_type.py
@@ -7,8 +7,8 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import JsonOpenError
@@ -20,7 +20,7 @@ def check_test_cnt(
     paths: Sequence[str], manifest: Dict[str, Any], required_tests: Dict[str, int]
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_parents_and_childs.py
+++ b/pre_commit_dbt/check_model_parents_and_childs.py
@@ -7,8 +7,8 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import get_parent_childs
 from pre_commit_dbt.utils import JsonOpenError
@@ -20,7 +20,7 @@ def check_child_parent_cnt(
     required_cnt: Sequence[Dict[str, Any]],
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/check_model_tags.py
+++ b/pre_commit_dbt/check_model_tags.py
@@ -6,8 +6,8 @@ from typing import Sequence
 
 from pre_commit_dbt.utils import add_filenames_args
 from pre_commit_dbt.utils import add_manifest_args
-from pre_commit_dbt.utils import get_filenames
 from pre_commit_dbt.utils import get_json
+from pre_commit_dbt.utils import get_model_sqls
 from pre_commit_dbt.utils import get_models
 from pre_commit_dbt.utils import JsonOpenError
 
@@ -16,7 +16,7 @@ def validate_tags(
     paths: Sequence[str], manifest: Dict[str, Any], tags: Sequence[str]
 ) -> int:
     status_code = 0
-    sqls = get_filenames(paths, [".sql"])
+    sqls = get_model_sqls(paths, manifest)
     filenames = set(sqls.keys())
 
     # get manifest nodes that pre-commit found as changed

--- a/pre_commit_dbt/utils.py
+++ b/pre_commit_dbt/utils.py
@@ -125,6 +125,17 @@ def get_flags(flags: Optional[Sequence[str]] = None) -> List[str]:
         return []
 
 
+def get_macro_sqls(manifest: Dict[str, Any]) -> Dict[str, Path]:
+    macro_paths = [m["path"] for m in manifest.get("macros", {}).values()]
+    return get_filenames(macro_paths, extensions=[".sql"])
+
+
+def get_model_sqls(paths: Sequence[str], manifest: Dict[str, Any]) -> Dict[str, Any]:
+    sqls = get_filenames(paths, [".sql"])
+    macro_sqls = get_macro_sqls(manifest)
+    return {k: v for k, v in sqls.items() if k not in macro_sqls}
+
+
 def get_model_schemas(
     yml_files: Sequence[Path], filenames: Set[str], all_schemas: bool = False
 ) -> Generator[ModelSchema, None, None]:


### PR DESCRIPTION
- Add util function to get model sqls (without macros) using the manifest
- Update all `check-model` hooks to use it